### PR TITLE
deleted warning against installing Windows 11 25H2 26200.7XXX or higher due to BSoD issue.

### DIFF
--- a/guide/Polski/3-install.md
+++ b/guide/Polski/3-install.md
@@ -63,7 +63,6 @@ exit
 
 ### Instalowanie Windowsa
 > [!Important]
-> Do not install, or update to, Windows 11 25H2 26200.7XXX or higher! You will not be able to boot into this build due to a BSoD issue!
 
 > Zamień `ścieżka\do\install.esd` na rzeczywistą ścieżkę do pliku install.esd (może on również nosić nazwę install.wim lub 22631.2861.XXXXXXX.esd)
 ```cmd

--- a/guide/Russian/3-install-ru.md
+++ b/guide/Russian/3-install-ru.md
@@ -63,7 +63,6 @@ exit
 
 ### Установка Windows
 > [!Important]
-> Do not install, or update to, Windows 11 25H2 26200.7XXX or higher! You will not be able to boot into this build due to a BSoD issue!
 
 > Замените `путь\к\install.esd` актуальным путём к install.esd (файл также может называться install.wim или 22631.2861.XXXXXXX.esd)
 ```cmd


### PR DESCRIPTION
deleted warning against installing Windows 11 25H2 26200.7XXX or higher due to BSoD issue.